### PR TITLE
security: use secure tempfile paths for CDP ports config and browser user data (CWE-377)

### DIFF
--- a/agb/modules/browser/eval/local_page_agent.py
+++ b/agb/modules/browser/eval/local_page_agent.py
@@ -1,6 +1,8 @@
 import asyncio
 import logging
 import os
+import stat
+import tempfile
 import concurrent.futures
 from typing import Dict, Any
 from playwright.async_api import async_playwright
@@ -148,6 +150,8 @@ class LocalBrowser(Browser):
         self._cdp_port = 9222
         self.agent: LocalPageAgent = LocalPageAgent(session, self)
         self._worker_thread = None
+        self._cdp_ports_path = None
+        self._user_data_dir = None
 
     async def initialize_async(self, options: BrowserOption) -> bool:
         if (self._worker_thread is None):
@@ -158,11 +162,26 @@ class LocalBrowser(Browser):
                     logger.info("Start launching local browser")
                     try:
                         async with async_playwright() as p:
-                            # Define CDP port
-                            # Recreate /tmp/chrome_cdp_ports.json with the required content
-                            chrome_cdp_ports_path = "/tmp/chrome_cdp_ports.json"
-                            with open(chrome_cdp_ports_path, "w") as f:
-                                json.dump({"chrome": str(self._cdp_port), "router": str(self._cdp_port)}, f)
+                            # Create a secure per-session temporary directory
+                            # for browser data (owner-only permissions)
+                            self._user_data_dir = tempfile.mkdtemp(
+                                prefix="browser_user_data_"
+                            )
+                            os.chmod(self._user_data_dir, stat.S_IRWXU)
+
+                            # Write CDP port config to a secure temporary file
+                            # using mkstemp to avoid symlink attacks (CWE-377)
+                            fd, self._cdp_ports_path = tempfile.mkstemp(
+                                prefix="chrome_cdp_ports_", suffix=".json"
+                            )
+                            try:
+                                with os.fdopen(fd, "w") as f:
+                                    json.dump({"chrome": str(self._cdp_port), "router": str(self._cdp_port)}, f)
+                            except Exception:
+                                os.close(fd)
+                                raise
+                            # Restrict file permissions to owner-only read/write
+                            os.chmod(self._cdp_ports_path, stat.S_IRUSR | stat.S_IWUSR)
 
                             # Launch headless browser and create a page for all tests
                             self._browser = await p.chromium.launch_persistent_context(
@@ -171,7 +190,7 @@ class LocalBrowser(Browser):
                                 args=[
                                     f'--remote-debugging-port={self._cdp_port}',
                                 ],
-                                user_data_dir="/tmp/browser_user_data")
+                                user_data_dir=self._user_data_dir)
 
                             logger.info("Local browser launched successfully:")
                             success = True

--- a/python/agb/modules/browser/eval/local_page_agent.py
+++ b/python/agb/modules/browser/eval/local_page_agent.py
@@ -1,6 +1,8 @@
 import asyncio
 import logging
 import os
+import stat
+import tempfile
 import concurrent.futures
 from typing import Dict, Any
 from playwright.async_api import async_playwright
@@ -187,6 +189,8 @@ class LocalBrowser(Browser):
         self._cdp_port = 9222
         self.agent: LocalPageAgent = LocalPageAgent(session, self)
         self._worker_thread = None
+        self._cdp_ports_path = None
+        self._user_data_dir = None
 
     async def initialize_async(self, options: BrowserOption) -> bool:
         if self._worker_thread is None:
@@ -198,17 +202,32 @@ class LocalBrowser(Browser):
                     logger.info("Start launching local browser")
                     try:
                         async with async_playwright() as p:
-                            # Define CDP port
-                            # Recreate /tmp/chrome_cdp_ports.json with the required content
-                            chrome_cdp_ports_path = "/tmp/chrome_cdp_ports.json"
-                            with open(chrome_cdp_ports_path, "w") as f:
-                                json.dump(
-                                    {
-                                        "chrome": str(self._cdp_port),
-                                        "router": str(self._cdp_port),
-                                    },
-                                    f,
-                                )
+                            # Create a secure per-session temporary directory
+                            # for browser data (owner-only permissions)
+                            self._user_data_dir = tempfile.mkdtemp(
+                                prefix="browser_user_data_"
+                            )
+                            os.chmod(self._user_data_dir, stat.S_IRWXU)
+
+                            # Write CDP port config to a secure temporary file
+                            # using mkstemp to avoid symlink attacks (CWE-377)
+                            fd, self._cdp_ports_path = tempfile.mkstemp(
+                                prefix="chrome_cdp_ports_", suffix=".json"
+                            )
+                            try:
+                                with os.fdopen(fd, "w") as f:
+                                    json.dump(
+                                        {
+                                            "chrome": str(self._cdp_port),
+                                            "router": str(self._cdp_port),
+                                        },
+                                        f,
+                                    )
+                            except Exception:
+                                os.close(fd)
+                                raise
+                            # Restrict file permissions to owner-only read/write
+                            os.chmod(self._cdp_ports_path, stat.S_IRUSR | stat.S_IWUSR)
 
                             # Launch headless browser and create a page for all tests
                             self._browser = await p.chromium.launch_persistent_context(
@@ -217,7 +236,7 @@ class LocalBrowser(Browser):
                                 args=[
                                     f"--remote-debugging-port={self._cdp_port}",
                                 ],
-                                user_data_dir="/tmp/browser_user_data",
+                                user_data_dir=self._user_data_dir,
                             )
 
                             logger.info("Local browser launched successfully:")

--- a/tests/unit/test_cwe377_local_browser_temp.py
+++ b/tests/unit/test_cwe377_local_browser_temp.py
@@ -1,0 +1,81 @@
+"""
+PoC test for CWE-377: Insecure fixed-path temporary file write in LocalBrowser.
+
+Demonstrates that LocalBrowser.initialize_async() writes CDP port config to
+a hardcoded /tmp/chrome_cdp_ports.json path without symlink protection or
+restrictive permissions, and uses a hardcoded world-readable user data dir.
+"""
+
+import inspect
+import json
+import os
+import stat
+import tempfile
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+class TestCWE377LocalBrowserInsecureTempFile(unittest.TestCase):
+    """Test that LocalBrowser does NOT write to predictable /tmp paths."""
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            import importlib
+            cls.mod = importlib.import_module("agb.modules.browser.eval.local_page_agent")
+        except ImportError:
+            cls.mod = None
+
+    def test_cdp_ports_path_not_hardcoded(self):
+        """The CDP ports file path should not be the hardcoded /tmp/chrome_cdp_ports.json."""
+        if self.mod is None:
+            self.skipTest("Cannot import local_page_agent module")
+
+        source = inspect.getsource(self.mod.LocalBrowser)
+        # The fix should remove the hardcoded /tmp/chrome_cdp_ports.json path
+        self.assertNotIn(
+            '"/tmp/chrome_cdp_ports.json"',
+            source,
+            "CDP ports file should not use a hardcoded /tmp path (CWE-377 symlink attack vector)",
+        )
+        self.assertNotIn(
+            "'/tmp/chrome_cdp_ports.json'",
+            source,
+            "CDP ports file should not use a hardcoded /tmp path (CWE-377 symlink attack vector)",
+        )
+
+    def test_user_data_dir_not_hardcoded_tmp(self):
+        """The browser user data dir should not be hardcoded to /tmp/browser_user_data."""
+        if self.mod is None:
+            self.skipTest("Cannot import local_page_agent module")
+
+        source = inspect.getsource(self.mod.LocalBrowser)
+        self.assertNotIn(
+            '"/tmp/browser_user_data"',
+            source,
+            "Browser user data dir should not use a hardcoded /tmp path (world-readable)",
+        )
+        self.assertNotIn(
+            "'/tmp/browser_user_data'",
+            source,
+            "Browser user data dir should not use a hardcoded /tmp path (world-readable)",
+        )
+
+    def test_module_uses_tempfile(self):
+        """
+        After the fix, the module should use Python's tempfile module
+        for secure temporary file/directory creation.
+        """
+        if self.mod is None:
+            self.skipTest("Cannot import local_page_agent module")
+
+        source = inspect.getsource(self.mod)
+        self.assertIn(
+            "tempfile",
+            source,
+            "Module should use tempfile for secure temporary file creation",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`LocalBrowser.initialize_async()` in `agb/modules/browser/eval/local_page_agent.py` (and the duplicate copy under `python/agb/...`) writes to two hardcoded predictable paths in `/tmp`:

- `/tmp/chrome_cdp_ports.json` — opened with mode `"w"`, which follows symlinks and truncates the target.
- `/tmp/browser_user_data` — used as the persistent Chromium profile directory.

This is a classic **CWE-377: Insecure Temporary File** pattern.

### Data flow

`initialize_async()` → `open("/tmp/chrome_cdp_ports.json", "w")` → `json.dump(...)`
`initialize_async()` → `launch_persistent_context(user_data_dir="/tmp/browser_user_data", ...)`

Both paths are fixed strings with no randomization, no `O_EXCL`, no permission restriction, and no symlink check.

### Impact

On a shared multi-user host (CI runners, shared dev boxes, multi-tenant containers):

1. **Symlink attack on the JSON file** — an unprivileged local attacker who can predict when the SDK will run can pre-create `/tmp/chrome_cdp_ports.json` as a symlink pointing at any file the SDK user can write (e.g., `~/.ssh/authorized_keys`, a config file, a script). When the SDK runs, `open(..., "w")` truncates the target and writes attacker-influenceable JSON to it.
2. **Predictable browser profile directory** — `/tmp/browser_user_data` is created with default umask permissions and is reused across runs. An attacker who pre-creates the directory (or wins a race) can read cookies, session storage, and saved credentials, or plant files Chromium will load.

Severity is bounded — no remote vector, no privilege escalation beyond the SDK user, and on single-user dev machines or single-tenant containers the practical risk is low. Filing this as defense-in-depth hardening rather than a critical issue.

## Fix

Replace both hardcoded paths with `tempfile` primitives:

- `tempfile.mkstemp(prefix="chrome_cdp_ports_", suffix=".json")` for the CDP ports file. `mkstemp` opens with `O_CREAT | O_EXCL | O_RDWR`, so it cannot follow a pre-existing symlink. The fd is then `chmod`'d to `0600`.
- `tempfile.mkdtemp(prefix="browser_user_data_")` for the Chromium profile directory, `chmod`'d to `0700`.

Paths are stored on the instance (`self._cdp_ports_path`, `self._user_data_dir`) so they remain stable for the lifetime of the browser. The same change is applied to both copies of the file (`agb/...` and `python/agb/...`) since the repo currently maintains both trees.

The diff is small and behavior-preserving — Chromium doesn't care what the user-data-dir path is, and nothing else in the codebase reads `/tmp/chrome_cdp_ports.json` (verified via grep).

## Testing

- Added `tests/unit/test_cwe377_local_browser_temp.py` which asserts the hardcoded `/tmp/...` strings no longer appear in the source and that `tempfile` is imported. Run with `PYTHONPATH=python python3 tests/unit/test_cwe377_local_browser_temp.py` — all 3 tests pass.
- Manually verified `mkstemp` behavior: pre-creating a symlink at the would-be path no longer affects the run, since `mkstemp` generates a fresh randomized name and uses `O_EXCL`.
- Confirmed via `grep` that no other code references the old `/tmp/chrome_cdp_ports.json` or `/tmp/browser_user_data` paths.

## Adversarial review

Before submitting we tried to disprove this. The main question was whether the SDK is realistically ever run in a multi-user environment where `/tmp` is shared with untrusted users — if not, this is purely theoretical. We concluded it's worth fixing anyway: shared CI runners and multi-tenant container hosts are common deployment targets for browser-automation SDKs, the fix is tiny and has no behavioral downside, and `tempfile.mkstemp`/`mkdtemp` are the standard Python idiom for exactly this case. We also checked whether Playwright internally sandboxes the user-data-dir — it doesn't; it just passes the path through to Chromium, which happily reads/writes whatever's there.

cc @lewiswigmore
