### PR TITLE
fix(file_transfer): strip query params from pre-signed URLs before logging (CWE-532)

### DIFF
--- a/python/agb/modules/file_transfer.py
+++ b/python/agb/modules/file_transfer.py
@@ -7,6 +7,7 @@ import json
 import os
 import time
 from pathlib import PurePosixPath
+from urllib.parse import urlsplit
 from typing import Callable, Dict, Optional, Tuple
 
 import httpx
@@ -22,6 +23,12 @@ from agb.model.response import UploadResult, DownloadResult
 
 # Initialize logger for this module
 logger = get_logger("file_transfer")
+
+
+def _sanitize_url(url: str) -> str:
+    """Return URL with query string removed to avoid leaking pre-signed tokens."""
+    parts = urlsplit(url)
+    return parts._replace(query="", fragment="").geturl()
 
 
 class FileTransfer:
@@ -222,7 +229,7 @@ class FileTransfer:
         upload_url = url_res.url
         req_id_upload = getattr(url_res, "request_id", None)
 
-        logger.info(f"Uploading {local_path} to OSS (URL: {upload_url})")
+        logger.info(f"Uploading {local_path} to OSS (URL: {_sanitize_url(upload_url)})")
 
         # 2. PUT upload to pre-signed URL
         try:
@@ -483,7 +490,7 @@ class FileTransfer:
                     error_message=f"Destination exists and overwrite=False: {local_path}",
                 )
 
-            logger.info(f"Downloading from OSS to {local_path} (URL: {download_url})")
+            logger.info(f"Downloading from OSS to {local_path} (URL: {_sanitize_url(download_url)})")
             http_status, bytes_received = self._get_file_sync(
                 download_url,
                 local_path,

--- a/python/tests/unit/test_cwe532_presigned_url_leak.py
+++ b/python/tests/unit/test_cwe532_presigned_url_leak.py
@@ -1,0 +1,199 @@
+"""
+PoC test for CWE-532: Pre-signed URLs logged in plaintext (file_transfer.py).
+
+Pre-signed upload/download URLs contain authentication tokens in query-string
+parameters (e.g. Signature, OSSAccessKeyId, Expires).  These are bearer tokens:
+anyone who reads log output can use them.
+
+The test captures log output emitted by FileTransfer.upload() and
+FileTransfer.download() and asserts it does NOT contain the query parameters.
+"""
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from loguru import logger
+
+from agb.modules.file_transfer import FileTransfer
+
+# ---------------------------------------------------------------------------
+# Fakes (same pattern as existing unit tests)
+# ---------------------------------------------------------------------------
+
+PRESIGNED_UPLOAD_URL = (
+    "https://bucket.oss-cn-hangzhou.aliyuncs.com/path/file.txt"
+    "?OSSAccessKeyId=AKID1234567890"
+    "&Expires=1719999999"
+    "&Signature=dGhpcyBpcyBhIHNlY3JldA%3D%3D"
+)
+
+PRESIGNED_DOWNLOAD_URL = (
+    "https://bucket.oss-cn-hangzhou.aliyuncs.com/path/remote.txt"
+    "?OSSAccessKeyId=AKID0987654321"
+    "&Expires=1720000000"
+    "&Signature=c2Vuc2l0aXZlc2lnbmF0dXJl"
+)
+
+
+class _FakeInternalContextResponse:
+    def __init__(self, ok=True, data=None, err=None):
+        self._ok = ok
+        self._data = data
+        self._err = err
+
+    def is_successful(self):
+        return self._ok
+
+    def get_error_message(self):
+        return self._err
+
+    def get_context_list(self):
+        return self._data
+
+
+class _FakeSession:
+    def __init__(self, sid="s1"):
+        self._sid = sid
+        self.context = SimpleNamespace()
+
+    def get_session_id(self):
+        return self._sid
+
+
+class _FakeClient:
+    def __init__(self, resp):
+        self._resp = resp
+
+    def get_and_load_internal_context(self, request):
+        return self._resp
+
+
+class _FakeContextSvc:
+    def __init__(self, upload_url=None, download_url=None):
+        self._up = upload_url
+        self._dl = download_url
+
+    def get_file_upload_url(self, cid, path):
+        return self._up
+
+    def get_file_download_url(self, cid, path):
+        return self._dl
+
+
+class _FakeAGB:
+    def __init__(self, api_key="ak", client=None, context=None):
+        self.api_key = api_key
+        self.client = client
+        self.context = context
+
+
+# ---------------------------------------------------------------------------
+# Helper: capture loguru output as a list of strings
+# ---------------------------------------------------------------------------
+
+class _LogCapture:
+    """Sink for loguru that stores messages."""
+
+    def __init__(self):
+        self.messages: list[str] = []
+
+    def write(self, message):
+        self.messages.append(str(message))
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_upload_does_not_log_presigned_url_query_params(tmp_path):
+    """upload() must not emit pre-signed URL query parameters to logs."""
+    # Prepare local file
+    local = tmp_path / "data.bin"
+    local.write_bytes(b"hello")
+
+    resp = _FakeInternalContextResponse(
+        ok=True, data=[{"contextId": "cid", "contextPath": "/tmp"}]
+    )
+    url_res = SimpleNamespace(
+        success=True,
+        url=PRESIGNED_UPLOAD_URL,
+        request_id="rid-up",
+        message=None,
+    )
+    agb = _FakeAGB(
+        client=_FakeClient(resp),
+        context=_FakeContextSvc(upload_url=url_res),
+    )
+    ft = FileTransfer(agb, _FakeSession("s-1"))
+
+    # Capture logs
+    capture = _LogCapture()
+    handler_id = logger.add(capture, format="{message}", level="DEBUG")
+
+    try:
+        with patch.object(ft, "_put_file_sync", return_value=(200, "etag", 5)):
+            with patch.object(ft, "_await_sync", return_value="rid-sync"):
+                ft.upload(str(local), "/path/file.txt", wait=False)
+    finally:
+        logger.remove(handler_id)
+
+    all_logs = "\n".join(capture.messages)
+
+    # The URL path is fine to log, but query params with secrets must NOT appear
+    assert "OSSAccessKeyId" not in all_logs, (
+        f"Pre-signed URL query parameter leaked in logs:\n{all_logs}"
+    )
+    assert "Signature" not in all_logs, (
+        f"Pre-signed URL signature leaked in logs:\n{all_logs}"
+    )
+    assert "Expires" not in all_logs, (
+        f"Pre-signed URL expiry leaked in logs:\n{all_logs}"
+    )
+
+
+def test_download_does_not_log_presigned_url_query_params(tmp_path):
+    """download() must not emit pre-signed URL query parameters to logs."""
+    resp = _FakeInternalContextResponse(
+        ok=True, data=[{"contextId": "cid", "contextPath": "/tmp"}]
+    )
+    dl_url_res = SimpleNamespace(
+        success=True,
+        url=PRESIGNED_DOWNLOAD_URL,
+        request_id="rid-dl",
+        message=None,
+    )
+    agb = _FakeAGB(
+        client=_FakeClient(resp),
+        context=_FakeContextSvc(download_url=dl_url_res),
+    )
+    ft = FileTransfer(agb, _FakeSession("s-2"))
+
+    capture = _LogCapture()
+    handler_id = logger.add(capture, format="{message}", level="DEBUG")
+
+    def _fake_get(url, dest, *a, **k):
+        with open(dest, "wb") as f:
+            f.write(b"data")
+        return 200, 4
+
+    try:
+        with patch.object(ft, "_await_sync", return_value="rid-sync"):
+            with patch.object(ft, "_get_file_sync", side_effect=_fake_get):
+                ft.download("/path/remote.txt", str(tmp_path / "out.bin"), wait=False)
+    finally:
+        logger.remove(handler_id)
+
+    all_logs = "\n".join(capture.messages)
+
+    assert "OSSAccessKeyId" not in all_logs, (
+        f"Pre-signed URL query parameter leaked in logs:\n{all_logs}"
+    )
+    assert "Signature" not in all_logs, (
+        f"Pre-signed URL signature leaked in logs:\n{all_logs}"
+    )
+    assert "Expires" not in all_logs, (
+        f"Pre-signed URL expiry leaked in logs:\n{all_logs}"
+    )


### PR DESCRIPTION
## Summary

Pre-signed OSS URLs are logged in plaintext at INFO level by `FileTransfer.upload()` and `FileTransfer.download()` in `python/agb/modules/file_transfer.py`. These URLs contain bearer-token query parameters (`Signature`, `OSSAccessKeyId`, `Expires`) — anyone who reads the log line within the URL's expiry window can replay it to read or write the corresponding object, no API key required.

- **CWE:** CWE-532 (Insertion of Sensitive Information into Log File)
- **File:** `python/agb/modules/file_transfer.py`
- **Affected functions:** `FileTransfer.upload()` (line ~225), `FileTransfer.download()` (line ~486)
- **Severity:** Medium — credentials-equivalent material written to logs at default verbosity

### Data flow

1. `agb.context.get_file_upload_url(...)` / `get_file_download_url(...)` returns a pre-signed OSS URL whose query string carries the OSS signature.
2. The URL is passed straight into `logger.info(f"... URL: {upload_url}")` / `logger.info(f"... URL: {download_url}")`.
3. The default loguru sink writes INFO-level records to stderr and (in typical deployments) to file/aggregator sinks. Anyone with read access to those logs gets the full pre-signed URL.

## Fix

Add a small `_sanitize_url()` helper that uses `urllib.parse.urlsplit` to strip the query string and fragment, and apply it at the two log sites:

```python
def _sanitize_url(url: str) -> str:
    """Return URL with query string removed to avoid leaking pre-signed tokens."""
    parts = urlsplit(url)
    return parts._replace(query="", fragment="").geturl()
```

The host and path are still logged (useful for debugging which bucket/object was touched); only the signing parameters are removed. The URL value used for the actual HTTP PUT/GET is unchanged — only the *logged* representation is sanitized.

I checked `python/agb/modules/context.py` as well, since it also handles pre-signed URLs; it never logs the URL string (only `context_id`, `file_path`, `request_id`), so no changes are needed there. These two log statements in `file_transfer.py` are the only places URLs were emitted in this module.

## Tests

Added `python/tests/unit/test_cwe532_presigned_url_leak.py` with two cases:

- `test_upload_does_not_log_presigned_url_query_params` — exercises `upload()` with a fake pre-signed URL containing `OSSAccessKeyId`, `Expires`, `Signature`, captures loguru output, asserts none of those tokens appear.
- `test_download_does_not_log_presigned_url_query_params` — same for `download()`.

Both tests fail against the current code on `master` (the URL with all query params is logged verbatim) and pass with the fix applied. The existing file_transfer test suite continues to pass — the change is confined to log formatting.

## Security analysis

Why this is exploitable in practice:

- Pre-signed OSS URLs are valid for the entire `Expires` window (typically minutes to hours). During that window, possession of the URL = possession of the object.
- INFO is the default log level; these messages are emitted during normal SDK use, not just in debug mode.
- Common log destinations (centralized logging, container stdout collected by the platform, on-disk files, error reports, support bundles) routinely have a broader read audience than the API key itself.

Preconditions for exploitation:

1. Read access to application logs (often a different and broader trust boundary than the API key).
2. The log entry is observed before the pre-signed URL expires.

### Adversarial review

Before submitting I tried to disprove this. The main "is it really a vuln?" angles:

- *"Maybe logs are already considered as sensitive as API keys."* In typical deployments they aren't — log aggregators, ops dashboards, and crash reports are normally accessible to people who don't hold the SDK's API key. Anyone in that group gains the ability to read/write the specific OSS object directly, which the API key alone wouldn't grant them without also going through the SDK.
- *"Maybe the URL doesn't actually contain credentials."* Verified by inspecting the OSS pre-signed URL format and the call sites — `Signature`, `OSSAccessKeyId`, `Expires` are present in the query string and are exactly the bearer material OSS validates.
- *"Maybe a framework-level redactor already strips it."* There's no logging filter/processor in this SDK that masks query strings; loguru is configured with the default formatter.

The preconditions (log read access) do not already grant equivalent OSS object access, so the fix provides a real reduction in blast radius.

cc @lewiswigmore
